### PR TITLE
Send xrp validation

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -427,7 +427,7 @@ I sincerely promise I've written my recovery phrase down.</p><br>
 <div id="tablogin" class="screentab" data-primarytab="true" data-title="Toast Wallet" data-dark="true" data-recovery="true" style="display: none;">
     
 	<center>
-	<div class="pinpad" style="">
+	<div class="pinpad">
 	    <div class="pinnumber">
 	    <i class="fa fa-circle-thin" aria-hidden="true"></i>&nbsp;
 		<i class="fa fa-circle-thin" aria-hidden="true"></i>&nbsp;
@@ -457,7 +457,7 @@ I sincerely promise I've written my recovery phrase down.</p><br>
 <div id="tabpinset1" class="screentab" data-primarytab="false" data-title="Set New PIN"  data-dark="2" data-noright="true" style="display: none;">
     
 	<center>
-	<div class="pinpad" style="">
+	<div class="pinpad">
 	    <div class="pinnumber">
 	    <i class="fa fa-circle-thin" aria-hidden="true"></i>&nbsp;
 		<i class="fa fa-circle-thin" aria-hidden="true"></i>&nbsp;
@@ -487,7 +487,7 @@ I sincerely promise I've written my recovery phrase down.</p><br>
 <div id="tabpinset2" class="screentab" data-primarytab="false" data-hasback="true"  data-dark="2" data-noright="true" data-title="Repeat New PIN" style="display: none;">
     
 	<center>
-	<div class="pinpad" style="">
+	<div class="pinpad">
 	    <div class="pinnumber">
 	    <i class="fa fa-circle-thin" aria-hidden="true"></i>&nbsp;
 		<i class="fa fa-circle-thin" aria-hidden="true"></i>&nbsp;

--- a/www/index.html
+++ b/www/index.html
@@ -1410,6 +1410,7 @@ var previoustabs = [];
 var activeaccount = "";
 var accountbalances = {};
 var userkey = ""; // user's sha1 of passphrase used to decrypt wallet secrets
+var XRP_RESERVE_AMOUNT = 20;
 
 var screentabpaddingbottom = 0; // we use this when calcualting keyboard offset
 function showTab(tab, dontClearText) {
@@ -1675,6 +1676,19 @@ function doConfirmPay(passphrase) {
 
 			checkConnection(
 				function(){
+
+					if (isBelowReserveAmount(confirmpay.payfrom, parseFloat(confirmpay.amount))) {
+						navigator.notification.alert("Error! No payment was made because a reserve of " + XRP_RESERVE_AMOUNT + "xrp must remain in your wallet after your transaction.",
+							function() {
+								showTab(-1);
+								unblockInput();
+							}, 
+							"Error",
+							"OK"
+						);
+						return;
+					}
+
 					sendXRP(passphrase, confirmpay.payfrom, parseFloat(confirmpay.amount), confirmpay.payto, 0, confirmpay.dest, confirmpay.invid, 
 						function(){
 							navigator.notification.alert("Your payment was successfully sent.", 
@@ -1719,6 +1733,11 @@ function doConfirmPay(passphrase) {
 	);
 }
 
+function isBelowReserveAmount(accountFrom, amountToSend) {
+	var amountAfterTransaction = accountbalances[accountFrom] - parseFloat(amountToSend);
+
+	return amountAfterTransaction < XRP_RESERVE_AMOUNT;
+}
 
 var confirmpay = {};
 var confirmpayhash = "";


### PR DESCRIPTION
Hi, I'd like to add a pull request for preventing a transaction from being sent when the amount would leave less than the required 20xrp in the account.

The advantage would be to fail the transaction before it's sent on the network so that the user doesn't lose 0.00001xrp and to provide a descriptive error message so the user knows why the transaction was rejected.

I wasn't able to build or test if the code works so could you please try it out before merging?

Thanks :)