### PR TITLE
Give error when sending below XRP reserve

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -1585,7 +1585,9 @@ var previoustabs = [];
 var activeaccount = "";
 var accountbalances = {};
 var userkey = ""; // user's sha1 of passphrase used to decrypt wallet secrets
-var xrpreserveamount = document.getElementbyId('reserveBaseXRP');
+var xrpreserveamount = getServerInfo().then(obj => {
+			obj.validatedLedger.reserveBaseXRP
+})
 				       
 var screentabpaddingbottom = 0; // we use this when calcualting keyboard offset
 function showTab(tab, dontClearText) {

--- a/www/index.html
+++ b/www/index.html
@@ -1947,7 +1947,7 @@ function doConfirmPay(passphrase) {
 
 			checkConnection(
 				function(){
-			
+					// xrp reserve check contributed by https://github.com/CheungJ and https://github.com/SneakyFish5
  					if (isBelowReserveAmount(confirmpay.payfrom, parseFloat(confirmpay.amount))) {
  						navigator.notification.alert("Error! No payment was made because a reserve of " + xrpreserveamount + "xrp must remain in your wallet after your transaction.",
  							function() {

--- a/www/index.html
+++ b/www/index.html
@@ -1585,7 +1585,8 @@ var previoustabs = [];
 var activeaccount = "";
 var accountbalances = {};
 var userkey = ""; // user's sha1 of passphrase used to decrypt wallet secrets
-
+var xrpreserveamount = document.getElementbyId('reserveBaseXRP');
+				       
 var screentabpaddingbottom = 0; // we use this when calcualting keyboard offset
 function showTab(tab, dontClearText) {
 
@@ -1944,7 +1945,20 @@ function doConfirmPay(passphrase) {
 
 			checkConnection(
 				function(){
-					sendXRP(passphrase, confirmpay.payfrom, parseFloat(confirmpay.amount), confirmpay.payto, 0, confirmpay.dest, confirmpay.invid, 
+			
+ 					if (isBelowReserveAmount(confirmpay.payfrom, parseFloat(confirmpay.amount))) {
+ 						navigator.notification.alert("Error! No payment was made because a reserve of " + xrpreserveamount + "xrp must remain in your wallet after your transaction.",
+ 							function() {
+ 								showTab(-1);
+ 								unblockInput();
+ 							}, 
+ 							"Error",
+ 							"OK"
+ 						);
+ 						return;
+ 					}
+ 
+			sendXRP(passphrase, confirmpay.payfrom, parseFloat(confirmpay.amount), confirmpay.payto, 0, confirmpay.dest, confirmpay.invid, 
 						function(){
 
 							if (confirmpay.payto == 'rToastMYRQh8boeo5Ys1CnPySmt3c9x3Y') {
@@ -2011,6 +2025,11 @@ function doConfirmPay(passphrase) {
 	);
 }
 
+function isBelowReserveAmount(accountFrom, amountToSend) {
+ 	var amountAfterTransaction = accountbalances[accountFrom] - parseFloat(amountToSend);
+
+ 	return amountAfterTransaction < xrpreserveamount;
+ }
 
 var confirmpay = {};
 var confirmpayhash = "";


### PR DESCRIPTION
As of now, when you try to send a tx and it dips into reserve amount, the tx never works but it uses up the tx fee. Using some code from PR #2 and my own code, I used `getServerInfo()` to pull the reserve amount from ripple-lib.